### PR TITLE
Add scheduler framework with YouTube engagement tasks

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,20 @@
 from flask import Flask
 
+try:
+    from .db import init_db
+except Exception:
+    init_db = None  # type: ignore
+
+try:
+    from flask_socketio import SocketIO
+except Exception:
+    SocketIO = None  # type: ignore
+
+try:
+    from .tasks import init_scheduler
+except Exception:
+    init_scheduler = None  # type: ignore
+
 
 def create_app():
     app = Flask(
@@ -11,5 +26,24 @@ def create_app():
 
     from . import routes
     routes.init_app(app)
+
+    session_factory = None
+    if init_db:
+        try:
+            session_factory = init_db()
+        except Exception as exc:  # pragma: no cover - optional dependency
+            app.logger.warning("Database unavailable: %s", exc)
+
+    socketio = None
+    if SocketIO:
+        socketio = SocketIO(app)
+        if init_scheduler and session_factory is not None:
+            try:
+                init_scheduler(app, session_factory, socketio)
+            except Exception as exc:  # pragma: no cover
+                app.logger.warning("Scheduler failed: %s", exc)
+
+    app.session_factory = session_factory
+    app.socketio = socketio
 
     return app

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+try:
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+except Exception as e:  # pragma: no cover - optional dependency
+    create_engine = None  # type: ignore
+    sessionmaker = None  # type: ignore
+
+from .models import Base
+
+
+def init_db(url: str = "sqlite:///app.db"):
+    """Initialize the database and return a session factory."""
+    if create_engine is None or sessionmaker is None:
+        raise RuntimeError("SQLAlchemy is not available")
+    engine = create_engine(url)
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)

--- a/app/models.py
+++ b/app/models.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     DateTime,
     Text,
     Enum,
+    func,
 )
 from sqlalchemy.orm import relationship, declarative_base
 
@@ -71,3 +72,29 @@ class PointsLedger(Base):
             f"<PointsLedger id={self.id} user_id={self.user_id} "
             f"points_delta={self.points_delta} reason={self.reason!r}>"
         )
+
+
+class OAuth(Base):
+    """Minimal token storage compatible with Flask-Dance."""
+
+    __tablename__ = 'oauth'
+
+    id = Column(Integer, primary_key=True)
+    provider = Column(String, nullable=False)
+    token = Column(Text, nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+
+    user = relationship('User')
+
+    def __repr__(self) -> str:
+        return (
+            f"<OAuth id={self.id} provider={self.provider!r} user_id={self.user_id}>"
+        )
+
+
+def get_total_points(session, user_id: int) -> int:
+    """Return the total points for a user."""
+    total = session.query(func.sum(PointsLedger.points_delta)).filter_by(
+        user_id=user_id
+    ).scalar()
+    return total or 0

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Optional
+
+from .models import EventType, Engagement, PointsLedger, OAuth, User, get_total_points
+
+
+RULES = {
+    "COMMENT": 5,
+    "LIKE": 2,
+    "SUPERCHAT": lambda amount: amount * 10,
+}
+
+
+def init_scheduler(app, session_factory, socketio=None):
+    """Initialize APScheduler job if dependencies are available."""
+    try:
+        from apscheduler.schedulers.background import BackgroundScheduler
+    except Exception as exc:  # pragma: no cover - optional dependency
+        app.logger.warning("APScheduler not available: %s", exc)
+        return None
+
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(
+        lambda: _update_engagements(app, session_factory, socketio),
+        "interval",
+        seconds=60,
+    )
+    scheduler.start()
+    return scheduler
+
+
+def _build_youtube_service(token: dict):
+    """Create a YouTube service from a stored OAuth token."""
+    try:
+        from google.oauth2.credentials import Credentials
+        from googleapiclient.discovery import build
+    except Exception:
+        return None
+    creds = Credentials(token.get("access_token"))
+    return build("youtube", "v3", credentials=creds)
+
+
+def _fetch_activities(service) -> list:
+    try:
+        resp = (
+            service.activities()
+            .list(part="snippet,contentDetails", mine=True)
+            .execute()
+        )
+    except Exception:
+        return []
+    return resp.get("items", [])
+
+
+def _update_engagements(app, session_factory, socketio=None):
+    if session_factory is None:
+        return
+    session = session_factory()
+    try:
+        oauth_rows = (
+            session.query(OAuth).filter(OAuth.provider == "youtube").all()
+        )
+        for oauth in oauth_rows:
+            try:
+                token = json.loads(oauth.token)
+            except Exception:
+                continue
+            service = _build_youtube_service(token)
+            if service is None:
+                continue
+            # Verify subscription still active
+            try:
+                service.subscriptions().list(part="id", mine=True).execute()
+            except Exception:
+                continue
+            # Pull activities
+            activities = _fetch_activities(service)
+            for item in activities:
+                event_id = item.get("id")
+                if not event_id:
+                    continue
+                if (
+                    session.query(Engagement)
+                    .filter_by(event_id=event_id, user_id=oauth.user_id)
+                    .first()
+                ):
+                    continue
+                etype = item.get("snippet", {}).get("type", "").upper()
+                if etype not in RULES:
+                    continue
+                engagement = Engagement(
+                    user_id=oauth.user_id,
+                    event_type=EventType[etype],
+                    event_id=event_id,
+                    timestamp=datetime.utcnow(),
+                    raw_json=json.dumps(item),
+                )
+                session.add(engagement)
+                rule = RULES[etype]
+                if callable(rule):
+                    amount = item.get("snippet", {}).get("superChatDetails", {}).get(
+                        "amountMicros", 0
+                    ) / 1_000_000
+                    points = int(rule(amount))
+                else:
+                    points = rule
+                ledger = PointsLedger(
+                    user_id=oauth.user_id,
+                    engagement=engagement,
+                    points_delta=points,
+                    reason=etype,
+                    timestamp=datetime.utcnow(),
+                )
+                session.add(ledger)
+            session.commit()
+            total = get_total_points(session, oauth.user_id)
+            if socketio is not None:
+                socketio.emit(
+                    "points_update", {"user_id": oauth.user_id, "total": total}
+                )
+    finally:
+        session.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
 Flask
 requests
 pytest
+SQLAlchemy
+APScheduler
+Flask-SocketIO
+Flask-Dance
+google-api-python-client

--- a/run.py
+++ b/run.py
@@ -3,4 +3,8 @@ from app import create_app
 app = create_app()
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    socketio = getattr(app, 'socketio', None)
+    if socketio is not None:
+        socketio.run(app, debug=True)
+    else:
+        app.run(debug=True)


### PR DESCRIPTION
## Summary
- introduce optional database setup and scheduler hooks
- implement basic points tracking models and helper
- add background task skeleton for polling YouTube engagements
- integrate optional SocketIO server
- extend dependencies list

## Testing
- `pytest -q` *(fails: command not found)*