### PR TITLE
Implement SocketIO leaderboard

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,6 +15,11 @@ try:
 except Exception:
     init_scheduler = None  # type: ignore
 
+try:
+    from .socket_events import init_socket_events
+except Exception:
+    init_socket_events = None  # type: ignore
+
 
 def create_app():
     app = Flask(
@@ -42,6 +47,11 @@ def create_app():
                 init_scheduler(app, session_factory, socketio)
             except Exception as exc:  # pragma: no cover
                 app.logger.warning("Scheduler failed: %s", exc)
+        if init_socket_events and session_factory is not None:
+            try:
+                init_socket_events(app, session_factory, socketio)
+            except Exception as exc:  # pragma: no cover
+                app.logger.warning("Socket events failed: %s", exc)
 
     app.session_factory = session_factory
     app.socketio = socketio

--- a/app/socket_events.py
+++ b/app/socket_events.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from flask_socketio import join_room
+
+from .models import User, get_total_points
+
+
+def init_socket_events(app, session_factory: Callable[[], Any] | None, socketio=None):
+    """Register socket events and start background jobs."""
+    if socketio is None or session_factory is None:
+        return None
+
+    @socketio.on("connect")
+    def on_connect():
+        join_room("public")
+
+    def leaderboard_loop():
+        while True:
+            session = session_factory()
+            try:
+                users = session.query(User).all()
+                board = [
+                    {"name": user.username, "points": get_total_points(session, user.id)}
+                    for user in users
+                ]
+                board.sort(key=lambda x: x["points"], reverse=True)
+                socketio.emit("leaderboard", board[:10], room="public")
+            finally:
+                session.close()
+            socketio.sleep(15)
+
+    socketio.start_background_task(leaderboard_loop)
+    return leaderboard_loop

--- a/tests/test_socket_events.py
+++ b/tests/test_socket_events.py
@@ -1,0 +1,65 @@
+import pytest
+from datetime import datetime
+
+from app.db import init_db
+from app.models import User, PointsLedger
+from app.socket_events import init_socket_events
+
+
+class DummySocketIO:
+    def __init__(self):
+        self.handlers = {}
+        self.started = False
+        self.emits = []
+
+    def on(self, name):
+        def decorator(func):
+            self.handlers[name] = func
+            return func
+        return decorator
+
+    def start_background_task(self, target):
+        self.started = True
+        self.task = target
+
+    def emit(self, event, data, room=None):
+        self.emits.append((event, data, room))
+
+    def sleep(self, sec):
+        raise StopIteration
+
+
+def test_init_socket_events(monkeypatch):
+    Session = init_db('sqlite:///:memory:')
+    session = Session()
+    user1 = User(username='alice')
+    user2 = User(username='bob')
+    session.add_all([user1, user2])
+    session.commit()
+    session.add_all([
+        PointsLedger(user_id=user1.id, points_delta=10, reason='test', timestamp=datetime.utcnow()),
+        PointsLedger(user_id=user2.id, points_delta=5, reason='test', timestamp=datetime.utcnow()),
+    ])
+    session.commit()
+    session.close()
+
+    socketio = DummySocketIO()
+    rooms = []
+    monkeypatch.setattr('app.socket_events.join_room', lambda room: rooms.append(room))
+
+    loop = init_socket_events(None, Session, socketio)
+
+    assert 'connect' in socketio.handlers
+    socketio.handlers['connect']()
+    assert rooms == ['public']
+    assert socketio.started is True
+
+    with pytest.raises(StopIteration):
+        loop()
+
+    assert socketio.emits
+    event, data, room = socketio.emits[0]
+    assert event == 'leaderboard'
+    assert room == 'public'
+    assert data[0]['name'] == 'alice'
+    assert data[0]['points'] == 10


### PR DESCRIPTION
## Summary
- enable socket event helpers on app init
- emit leaderboard updates from new socket_events module
- test new leaderboard background loop and connect event

## Testing
- `pytest -q` *(fails: command not found)*