### PR TITLE
Add dashboard route with leaderboard updates

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+<head>
+    <title>Dashboard</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
+</head>
+<body class="p-4">
+    <h1 class="text-2xl mb-4">Welcome {{ current_user.username }}</h1>
+    <p class="mb-4">Total Points: <span id="points">{{ current_user.points_total }}</span></p>
+    <h2 class="text-xl mb-2">Leaderboard</h2>
+    <ul id="leaderboard" class="list-disc pl-6"></ul>
+    <script>
+        const socket = io();
+        const currentUserId = {{ current_user.id or 'null' }};
+        socket.on('points_update', data => {
+            if (data.user_id === currentUserId) {
+                document.getElementById('points').textContent = data.total;
+            }
+        });
+        socket.on('leaderboard', board => {
+            const list = document.getElementById('leaderboard');
+            list.innerHTML = '';
+            board.forEach(item => {
+                const li = document.createElement('li');
+                li.textContent = `${item.name}: ${item.points}`;
+                list.appendChild(li);
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `/dashboard` route that checks login
- show points total and listen for SocketIO updates
- create new dashboard template using Tailwind

## Testing
- `pytest -q` *(fails: command not found)*