### PR TITLE
Add PayPal webhook payout handling

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,6 +25,11 @@ try:
 except Exception:
     init_socket_events = None  # type: ignore
 
+try:
+    from services.paypal_webhook import init_paypal_webhook
+except Exception:
+    init_paypal_webhook = None  # type: ignore
+
 
 def create_app():
     app = Flask(
@@ -36,6 +41,11 @@ def create_app():
 
     from . import routes
     routes.init_app(app)
+    if init_paypal_webhook:
+        try:
+            init_paypal_webhook(app)
+        except Exception as exc:  # pragma: no cover - optional dependency
+            app.logger.warning("PayPal webhook init failed: %s", exc)
 
     session_factory = None
     if init_db:

--- a/app/models.py
+++ b/app/models.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     DateTime,
     Text,
     Enum,
+    Boolean,
     func,
 )
 from sqlalchemy.orm import relationship, declarative_base
@@ -101,6 +102,21 @@ class OAuth(Base):
     def __repr__(self) -> str:
         return (
             f"<OAuth id={self.id} provider={self.provider!r} user_id={self.user_id}>"
+        )
+
+
+class GiveawayWinner(Base):
+    """Track winners pending payout."""
+
+    __tablename__ = "giveaway_winners"
+
+    id = Column(Integer, primary_key=True)
+    payout_item_id = Column(String, unique=True, nullable=False)
+    paid = Column(Boolean, nullable=False, default=False)
+
+    def __repr__(self) -> str:
+        return (
+            f"<GiveawayWinner id={self.id} payout_item_id={self.payout_item_id!r} paid={self.paid}>"
         )
 
 

--- a/services/paypal_webhook.py
+++ b/services/paypal_webhook.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import hmac
+import hashlib
+import json
+from typing import Any
+
+from flask import Blueprint, current_app, request, abort
+
+try:
+    from app.models import GiveawayWinner
+except Exception:  # pragma: no cover - SQLAlchemy optional
+    GiveawayWinner = None  # type: ignore
+
+bp = Blueprint("paypal_webhook", __name__)
+
+
+def _verify_signature() -> bool:
+    """Verify PayPal webhook using a shared secret."""
+    secret = current_app.config.get("PAYPAL_WEBHOOK_SECRET")
+    if not secret:
+        return False
+    signature = request.headers.get("PayPal-Transmission-Sig")
+    if not signature:
+        return False
+    expected = hmac.new(secret.encode(), request.get_data(), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature)
+
+
+@bp.route("/webhooks/paypal", methods=["POST"])
+def handle_webhook() -> tuple[str, int]:
+    if not _verify_signature():
+        abort(400)
+
+    payload: dict[str, Any] = request.get_json(silent=True) or {}
+    event_type = str(payload.get("event_type", "")).lower()
+    if "payout" in event_type and "completed" in event_type:
+        resource = payload.get("resource", {}) or {}
+        payout_item_id = resource.get("payout_item_id") or resource.get("payout_item", {}).get("payout_item_id")
+        if payout_item_id and GiveawayWinner is not None:
+            session_factory = getattr(current_app, "session_factory", None)
+            if session_factory is not None:
+                session = session_factory()
+                try:
+                    winner = session.query(GiveawayWinner).filter_by(payout_item_id=payout_item_id).first()
+                    if winner and not winner.paid:
+                        winner.paid = True
+                        session.commit()
+                finally:
+                    session.close()
+
+    return "", 204
+
+
+def init_paypal_webhook(app) -> None:
+    app.register_blueprint(bp)

--- a/tests/test_paypal_webhook.py
+++ b/tests/test_paypal_webhook.py
@@ -1,0 +1,47 @@
+import json
+import hmac
+import hashlib
+
+import pytest
+
+from app import create_app
+from app.db import init_db
+from app.models import GiveawayWinner
+
+
+@pytest.fixture()
+def app_and_session():
+    Session = init_db('sqlite:///:memory:')
+    app = create_app()
+    app.session_factory = Session
+    app.config.update({'TESTING': True, 'PAYPAL_WEBHOOK_SECRET': 'secret'})
+    return app, Session
+
+
+def test_payout_completed_marks_paid(app_and_session):
+    app, Session = app_and_session
+    session = Session()
+    gw = GiveawayWinner(payout_item_id='p1')
+    session.add(gw)
+    session.commit()
+    session.close()
+
+    client = app.test_client()
+    event = {
+        'event_type': 'PAYOUTS-ITEM.COMPLETED',
+        'resource': {'payout_item_id': 'p1'},
+    }
+    body = json.dumps(event).encode()
+    sig = hmac.new(b'secret', body, hashlib.sha256).hexdigest()
+    res = client.post(
+        '/webhooks/paypal',
+        data=body,
+        headers={'PayPal-Transmission-Sig': sig},
+        content_type='application/json',
+    )
+    assert res.status_code == 204
+
+    session = Session()
+    row = session.query(GiveawayWinner).filter_by(payout_item_id='p1').one()
+    assert row.paid is True
+    session.close()


### PR DESCRIPTION
## Summary
- create PayPal webhook service with `/webhooks/paypal` endpoint
- handle payout completion events and mark winners paid
- support new `GiveawayWinner` model
- register webhook service in app factory
- add tests for payout webhook

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*